### PR TITLE
chore: Use docker build for local dev

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,7 +7,7 @@ build:
   - linux/amd64
   artifacts:
   - image: injector
-    ko: {}
+    context: .
 manifests:
   helm:
     releases:


### PR DESCRIPTION
Instead of using ko, keep things consistent with the final product.
