### PR TITLE
chore: Create self-signed certificate authority

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,15 @@ helm-bootstrap: ## Add helm repos
 	helm repo update
 
 .PHONY: up
-up: asdf-bootstrap ## Run dev environment
+up: asdf-bootstrap helm-bootstrap ## Run dev environment
 	ctlptl apply -f ctlptl.yaml
+	helm upgrade --install cert-manager jetstack/cert-manager --set installCRDs=true --namespace cert-manager --create-namespace --version v1.12.3
 	skaffold dev
 
 .PHONY: ci
 ci: helm-bootstrap ## Setup CI environment
 	ctlptl apply -f ctlptl.yaml
+	helm upgrade --install cert-manager jetstack/cert-manager --set installCRDs=true --namespace cert-manager --create-namespace --version v1.12.3
 	skaffold run
 
 .PHONY: clean

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: cert-manager
-  repository: https://charts.jetstack.io
-  version: v1.12.3
-digest: sha256:89f705be7b2d72488b70250d408c5cff6320f8a2f78d237cb374b55213a39a09
-generated: "2023-08-30T20:53:51.194937424-06:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,8 +4,3 @@ description: A Helm chart for gke-tpu-env-injector
 type: application
 version: 0.1.0
 appVersion: "0.1.0"
-dependencies:
-  - name: cert-manager
-    condition: cert-manager.enabled
-    repository: https://charts.jetstack.io
-    version: v1.12.3

--- a/chart/templates/certificate.yaml
+++ b/chart/templates/certificate.yaml
@@ -1,0 +1,15 @@
+{{- if (index .Values "cert-manager" "enabled") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "chart.fullname" . }}
+spec:
+  dnsNames:
+  - {{ include "chart.fullname" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "chart.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "chart.fullname" . }}
+  secretName: {{ include "chart.fullname" . }}
+{{- end -}}

--- a/chart/templates/certificateauthority.yaml
+++ b/chart/templates/certificateauthority.yaml
@@ -1,0 +1,18 @@
+{{- if (index .Values "cert-manager" "enabled") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "chart.fullname" . }}-ca
+spec:
+  isCA: true
+  commonName: {{ include "chart.fullname" . }}
+  secretName: {{ include "chart.fullname" . }}-root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: {{ include "chart.fullname" . }}
+    kind: ClusterIssuer
+    group: cert-manager.io
+{{- end -}}

--- a/chart/templates/clusterissuer.yaml
+++ b/chart/templates/clusterissuer.yaml
@@ -1,0 +1,9 @@
+{{- if (index .Values "cert-manager" "enabled") }}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ include "chart.fullname" . }}
+spec:
+  selfSigned: {}
+{{- end -}}

--- a/chart/templates/issuer.yaml
+++ b/chart/templates/issuer.yaml
@@ -1,0 +1,10 @@
+{{- if (index .Values "cert-manager" "enabled") }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "chart.fullname" . }}
+spec:
+  ca:
+    secretName: {{ include "chart.fullname" . }}-root-secret
+{{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,4 +78,3 @@ affinity: {}
 
 cert-manager:
   enabled: false
-  installCRDs: true


### PR DESCRIPTION
In order to receive the webhooks, we need to be able to add TLS
termination to the application web server.
