### PR TITLE
fix: Handle when there are pre-existing env vars

### DIFF
--- a/samples/with_extra_env_vars.yaml
+++ b/samples/with_extra_env_vars.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+  - port: 80
+    name: web
+  clusterIP: None
+  selector:
+    app: nginx
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+  labels:
+    gke-tpu-env-injector.aaronbatilo.dev/inject: enabled
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  serviceName: "nginx"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+        gke-tpu-env-injector.aaronbatilo.dev/inject: enabled
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+          name: web
+        env:
+        - name: FOO
+          value: BAR

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -6,12 +6,12 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 helm upgrade --install cert-manager jetstack/cert-manager --set installCRDs=true --namespace cert-manager --create-namespace --version v1.12.3
 skaffold run
-sleep 3
 
 echo "====================================================================="
 echo "Testing what happens when no extra environment variables are provided"
 echo "====================================================================="
 kubectl apply -f ./samples/no_extra_env_vars.yaml
+sleep 10
 
 if [ "$(kubectl get pods web-0 -o jsonpath='{.spec.containers[0].env[0].name}')" != "TPU_WORKER_HOSTNAMES" ]; then
   echo "Expected TPU_WORKER_HOSTNAMES to be set, but it was not"
@@ -28,6 +28,40 @@ else
 fi
 
 kubectl delete -f ./samples/no_extra_env_vars.yaml
+
+echo "---"
+echo
+
+sleep 5
+
+echo "=================================================================="
+echo "Testing what happens when there are existing environment variables"
+echo "=================================================================="
+kubectl apply -f ./samples/with_extra_env_vars.yaml
+sleep 10
+
+if [ "$(kubectl get pods web-0 -o jsonpath='{.spec.containers[0].env[0].name}')" != "FOO" ]; then
+  echo "Expected first envvar to be FOO to be set, but it was not"
+  exit 1
+else
+  echo "FOO was the first envvar as expected"
+fi
+
+if [ "$(kubectl get pods web-0 -o jsonpath='{.spec.containers[0].env[1].name}')" != "TPU_WORKER_HOSTNAMES" ]; then
+  echo "Expected TPU_WORKER_HOSTNAMES to be set, but it was not"
+  exit 1
+else
+  echo "TPU_WORKER_HOSTNAMES was set as expected"
+fi
+
+if [ "$(kubectl get pods web-0 -o jsonpath='{.spec.containers[0].env[1].value}')" != "web-0.nginx,web-1.nginx,web-2.nginx" ]; then
+  echo "Expected TPU_WORKER_HOSTNAMES to be set to web-0.nginx,web-1.nginx,web-2.nginx, but it was not"
+  exit 1
+else
+  echo "TPU_WORKER_HOSTNAMES was set to expected value"
+fi
+
+kubectl delete -f ./samples/with_extra_env_vars.yaml
 
 echo "---"
 echo


### PR DESCRIPTION
The patch was an `add` operation but was setting the entire array of
EnvVars. Now, if there's already an EnvVar, we only add a single item
instead of set the entire array.

Closes #10
