### PR TITLE
chore: Bump helm chart default appVersion

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gke-tpu-env-injector
 description: A Helm chart for gke-tpu-env-injector
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "v0.3.0"


### PR DESCRIPTION
Installs v0.3.0 by default instead of 0.1.0 which didn't do anything
yet.
