### PR TITLE
chore: Add additionalArguments to chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gke-tpu-env-injector
 description: A Helm chart for gke-tpu-env-injector
 type: application
-version: 0.1.2
+version: 0.2.0
 appVersion: "v0.3.0"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -33,6 +33,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          {{- with .Values.additionalArguments }}
+          {{- range . }}
+          - {{ . | quote }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: https
               containerPort: 443

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -31,6 +31,10 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+additionalArguments: []
+# - --tls-cert-file=/etc/tls/tls.crt
+# - --tls-key-file=/etc/tls/tls.key
+
 service:
   type: ClusterIP
   port: 443


### PR DESCRIPTION
This will allow people to pass additional arguments to the application,
like specifying the locations of TLS certs.
