### PR TITLE
chore: Make volumes configurable

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gke-tpu-env-injector
 description: A Helm chart for gke-tpu-env-injector
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "v0.3.0"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -55,11 +55,14 @@ spec:
               scheme: HTTPS
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if (index .Values "cert-manager" "enabled") }}
           volumeMounts:
+          {{- if (index .Values "cert-manager" "enabled") }}
           - name: certs
             mountPath: /etc/tls/
             readOnly: true
+          {{- end -}}
+          {{- with .Values.additionalVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
           {{- end -}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -73,9 +76,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (index .Values "cert-manager" "enabled") }}
       volumes:
+      {{- if (index .Values "cert-manager" "enabled") }}
       - name: certs
         secret:
           secretName: {{ include "chart.fullname" . }}
+      {{- end -}}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 6 }}
       {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -35,9 +35,35 @@ additionalArguments: []
 # - --tls-cert-file=/etc/tls/tls.crt
 # - --tls-key-file=/etc/tls/tls.key
 
+volumes: []
+# - name: certs
+#   secret:
+#     secretName: gke-tpu-env-injector
+
+additionalVolumeMounts: []
+# - name: certs
+#   mountPath: /etc/tls/
+#   readOnly: true
+
 service:
   type: ClusterIP
   port: 443
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Allow helm chart users to configure the volumes that get mounted. This
way, if someone already has a certificate authority in their cluster,
and creates their own certs, they can mount them on their own.
